### PR TITLE
Update .travis.yml to include correct g++ version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,20 @@ cache:
   directories:
     - node_modules
 node_js:
- - '0.10'
- - '0.12'
- - '4.1'
+  - '0.10'
+  - '0.12'
+  - '4.1'
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 before_install:
   - npm -g install npm@latest
 install:
- - npm install
+  - npm install
 script:
- - npm test
+  - npm test


### PR DESCRIPTION
g++ 4.8 needed for correct module build on nodejs 4.x+.
