### PR TITLE
Changed install of PHP5 to PHP7

### DIFF
--- a/.setup/gatewaysetup.sh
+++ b/.setup/gatewaysetup.sh
@@ -40,7 +40,7 @@ sudo apt-get -y install nginx
 #sudo sed -e '/stretch/ s/^#*/#/' -i /etc/apt/sources.list
 #sudo apt-get update
 
-# echo -e "${CYAN}************* STEP: Install PHP5 *************${NC}"
+# echo -e "${CYAN}************* STEP: Install PHP7 *************${NC}"
 sudo apt-get -y install php-common php-cli php-fpm
 
 #install NodeJS

--- a/.setup/gatewaysetup.sh
+++ b/.setup/gatewaysetup.sh
@@ -41,7 +41,7 @@ sudo apt-get -y install nginx
 #sudo apt-get update
 
 # echo -e "${CYAN}************* STEP: Install PHP5 *************${NC}"
-sudo apt-get -y install php5-common php5-cli php5-fpm
+sudo apt-get -y install php-common php-cli php-fpm
 
 #install NodeJS
 echo -e "${CYAN}************* STEP: Install NodeJS *************${NC}"


### PR DESCRIPTION
There are no install candidates for these packages. The change to PHP7 has no obvious effect on the gateway.

```
server:~$ sudo apt install php5-common php5-cli php5-fpm -y
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Package php5-cli is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

Package php5-common is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

Package php5-fpm is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'php5-common' has no installation candidate
E: Package 'php5-cli' has no installation candidate
E: Package 'php5-fpm' has no installation candidate
```

General Info:
Moteino: Moteino-USB 915MHz
Gateway: Rasperry Pi 0w
OS: Raspbian 9.3 stretch
Kernel: armv6l Linux 4.9.80+