### PR TITLE
install additional deps needed by setup script and npm

### DIFF
--- a/.setup/gatewaysetup.sh
+++ b/.setup/gatewaysetup.sh
@@ -117,6 +117,7 @@ sudo wget -O - https://raw.githubusercontent.com/audstanley/NodeJs-Raspberry-Pi/
 sudo npm install -g npm
 
 echo -e "${CYAN}************* STEP: Setup Gateway app & dependencies *************${NC}"
+sudo apt-get -y install curl grep wget sed build-essential openssl whiptail
 sudo mkdir -p $APPSRVDIR    #main dir where gateway app lives
 cd $APPSRVDIR || exit
 


### PR DESCRIPTION
fixes #44 

This will ensure all the proper dependencies for gatewaysetup.sh and npm are installed. 
